### PR TITLE
Add sample creative, corporate and commercial websites

### DIFF
--- a/comercial.html
+++ b/comercial.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>EcoMarket</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>EcoMarket</h1>
+  </header>
+
+  <section class="banner">
+    <img src="https://via.placeholder.com/800x300?text=Producto+destacado" alt="Producto destacado">
+  </section>
+
+  <section id="catalogo">
+    <h2>Catálogo</h2>
+    <div class="cards">
+      <div class="card"><img src="https://via.placeholder.com/200?text=Taza" alt="Taza"><h3>Taza</h3><p>$150 MXN</p><button>Agregar al carrito</button></div>
+      <div class="card"><img src="https://via.placeholder.com/200?text=Libreta" alt="Libreta"><h3>Libreta</h3><p>$120 MXN</p><button>Agregar al carrito</button></div>
+      <div class="card"><img src="https://via.placeholder.com/200?text=Playera" alt="Playera"><h3>Playera</h3><p>$250 MXN</p><button>Agregar al carrito</button></div>
+      <div class="card"><img src="https://via.placeholder.com/200?text=Bolsa" alt="Bolsa"><h3>Bolsa</h3><p>$80 MXN</p><button>Agregar al carrito</button></div>
+    </div>
+  </section>
+
+  <section id="contacto">
+    <h2>Contacto</h2>
+    <p><a href="https://wa.me/521234567890" target="_blank">WhatsApp</a></p>
+  </section>
+</body>
+</html>

--- a/corporativo.html
+++ b/corporativo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Consultora Nexus</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="corp-header">
+    <div class="logo">Consultora Nexus</div>
+    <nav>
+      <a href="#servicios">Servicios</a>
+      <a href="#nosotros">Nosotros</a>
+      <a href="#contacto">Contacto</a>
+    </nav>
+  </header>
+
+  <section id="servicios">
+    <h2>Servicios</h2>
+    <div class="cards">
+      <div class="card"><h3>Estrategia</h3><p>Planes a la medida.</p></div>
+      <div class="card"><h3>Marketing</h3><p>Impulso de marca.</p></div>
+      <div class="card"><h3>Capacitación</h3><p>Talleres para tu equipo.</p></div>
+    </div>
+  </section>
+
+  <section id="nosotros">
+    <h2>Nosotros</h2>
+    <p>Misión: acompañar a empresas en su crecimiento.</p>
+    <p>Visión: ser aliados estratégicos.</p>
+    <p>Equipo: Ana, Luis y Marta.</p>
+  </section>
+
+  <section id="testimonios">
+    <h2>Testimonios</h2>
+    <blockquote>“Gracias a Nexus aumentamos nuestras ventas un 50%.” — Cliente satisfecho</blockquote>
+  </section>
+
+  <section id="contacto">
+    <h2>¿Listo para comenzar?</h2>
+    <a class="btn" href="#">Agenda tu cita</a>
+  </section>
+</body>
+</html>

--- a/creativo.html
+++ b/creativo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Sitio Creativo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>La ciencia como relato</h1>
+    <p>Storytelling digital para proyectos culturales.</p>
+  </header>
+
+  <section>
+    <img src="https://via.placeholder.com/800x300?text=Imagen+de+impacto" alt="Imagen de impacto">
+    <p>"Explorar las ideas a través del cuerpo y la palabra".</p>
+  </section>
+
+  <section>
+    <h2>Sobre el proyecto</h2>
+    <p>Soy una voz que mezcla ciencia y poesía para narrar el mundo desde otra mirada.</p>
+  </section>
+
+  <section>
+    <h2>Galería</h2>
+    <img src="https://via.placeholder.com/400x250?text=Foto+1" alt="Foto 1">
+    <img src="https://via.placeholder.com/400x250?text=Foto+2" alt="Foto 2">
+  </section>
+
+  <section>
+    <h2>Contacto</h2>
+    <form class="contact-form">
+      <input type="email" placeholder="Tu correo">
+      <textarea placeholder="Mensaje"></textarea>
+      <button type="submit">Enviar</button>
+    </form>
+  </section>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,82 +1,44 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
+  <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Carlos Galindo | Portafolio de micrositios</title>
-  <link rel="icon" href="favicon.png">
+  <title>Portafolio de sitios web</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <section class="intro">
-    <div>
-      <h1>Carlos Galindo</h1>
-      <p>Portafolio de micrositios narrativos, arte interactivo y comunicación digital</p>
-    </div>
-  </section>
-
-  <section>
-    <div class="part-section fade-in">
-      <h2>Micrositio: Una idea en el cuerpo</h2>
-      <p>Narrativa poética interactiva sobre cómo habitamos conceptos filosóficos desde el cuerpo.</p>
-      <p><a href="#">Ver demo completo</a></p>
-    </div>
-  </section>
-
-  <section>
-    <div class="part-section fade-in">
-      <h2>Sketches interactivos en p5.js</h2>
-      <p>Exploraciones visuales y conceptuales con código creativo.</p>
-      <iframe src="https://editor.p5js.org/bioliteraturas/full/mp_62PaaI"></iframe>
-      <iframe src="https://editor.p5js.org/embed/YOUR-SKETCH-ID-2"></iframe>
-    </div>
-  </section>
-
-  <section>
-    <div class="part-section fade-in">
-      <h2>Textos y escritos</h2>
-      <p>Reflexiones y piezas escritas sobre ciencia, arte, cuerpo y tecnología.</p>
-      <ul class="text-list">
-        <li><a href="textos/metaforas-cuerpo.html" target="_blank">Metáforas y cuerpo</a></li>
-        <li><a href="textos/poesia-enredada.html" target="_blank">Poesía enredada: un ejercicio transmedia</a></li>
-        <li><a href="textos/codigo-imaginado.html" target="_blank">Código imaginado y práctica poética</a></li>
+  <header>
+    <h1>Portafolio de sitios web</h1>
+    <nav>
+      <ul>
+        <li><a href="creativo.html">Creativo</a></li>
+        <li><a href="corporativo.html">Corporativo</a></li>
+        <li><a href="comercial.html">Comercial</a></li>
       </ul>
-    </div>
-  </section>
+    </nav>
+  </header>
 
-  <section>
-    <div class="part-section fade-in">
-      <h2>Servicios y paquetes</h2>
-      <p>Trabajo con proyectos culturales, artísticos y educativos que quieren comunicar de forma visual, sensible y accesible.</p>
-      <ul class="service-list">
-        <li><strong>🌀 Micrositio narrativo:</strong> Ideal para exhibiciones, textos, performance o archivo poético. Desde $3,500 MXN.</li>
-        <li><strong>🧬 Arte interactivo con p5.js:</strong> Visualizaciones generativas o narrativas programadas. Desde $1,200 MXN.</li>
-        <li><strong>🌐 Web informativa cultural:</strong> Sitio tipo cartelera o presentación de proyecto. Desde $2,800 MXN.</li>
-        <li><strong>📂 Carga en GitHub Pages:</strong> Publicación gratuita sin costo de hosting.</li>
-      </ul>
-      <p class="note">También puedo ayudarte a pensar el contenido, guion visual o estrategias narrativas digitales.</p>
-      <a href="mailto:carlos@ejemplo.com" class="btn">Solicitar cotización</a>
-    </div>
-  </section>
+  <main>
+    <section class="example">
+      <img src="https://via.placeholder.com/800x400?text=Sitio+Creativo" alt="Sitio creativo">
+      <h2>Creativo</h2>
+      <p>Ideal para artistas, escritores o proyectos culturales que buscan storytelling digital.</p>
+      <a class="btn" href="creativo.html">Ver ejemplo</a>
+    </section>
 
-  <section>
-    <div class="part-section fade-in">
-      <h2>Contacto</h2>
-      <p>¿Quieres un sitio narrativo, visual o interactivo para tu proyecto cultural?</p>
-      <p>Escríbeme a <a href="mailto:carlos@ejemplo.com">carlos@ejemplo.com</a> o sígueme en <a href="#">@carlosgalindo</a></p>
-    </div>
-  </section>
+    <section class="example">
+      <img src="https://via.placeholder.com/800x400?text=Sitio+Corporativo" alt="Sitio corporativo">
+      <h2>Corporativo</h2>
+      <p>Perfecto para pymes, startups o consultorías que necesitan presencia profesional en línea.</p>
+      <a class="btn" href="corporativo.html">Ver ejemplo</a>
+    </section>
 
-  <footer>
-    © 2025 Carlos Galindo — Portafolio digital de arte y tecnología
-  </footer>
-
-  <audio autoplay loop>
-    <source src="ambient.mp3" type="audio/mpeg">
-    Tu navegador no soporta audio HTML5.
-  </audio>
-
-  <script src="script.js"></script>
+    <section class="example">
+      <img src="https://via.placeholder.com/800x400?text=Sitio+Comercial" alt="Sitio comercial">
+      <h2>Comercial</h2>
+      <p>Prototipo de tienda sencilla para negocios locales o venta de productos.</p>
+      <a class="btn" href="comercial.html">Ver ejemplo</a>
+    </section>
+  </main>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -94,3 +94,119 @@ audio {
   bottom: 10px;
   left: 10px;
 }
+header {
+  background: #111;
+  color: #fff;
+  padding: 1em;
+  text-align: center;
+}
+
+header nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+}
+
+header nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.example {
+  min-height: auto;
+  margin: 2em auto;
+  max-width: 800px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.05);
+  padding: 1.5em;
+  text-align: center;
+}
+
+.example img {
+  width: 100%;
+  border-radius: 8px;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.contact-form button {
+  background: #111;
+  color: #fff;
+  border: none;
+  padding: 0.7em;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.corp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.corp-header nav a {
+  margin-left: 1em;
+}
+
+.logo {
+  font-weight: bold;
+}
+
+.cards {
+  display: flex;
+  gap: 1em;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.card {
+  background: #fff;
+  padding: 1em;
+  border-radius: 10px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+  width: 200px;
+  text-align: center;
+}
+
+.card img {
+  width: 100%;
+  border-radius: 5px;
+}
+
+.card button {
+  margin-top: 0.5em;
+  background: #111;
+  color: #fff;
+  border: none;
+  padding: 0.5em 1em;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.banner img {
+  width: 100%;
+  border-radius: 8px;
+}
+
+blockquote {
+  font-style: italic;
+  max-width: 600px;
+  margin: 1em auto;
+}


### PR DESCRIPTION
## Summary
- Replace landing page with navigation to three example site types
- Add creative microsite demo with gallery and contact form
- Add corporate landing page and simple e-commerce catalog demo
- Extend styles for navigation, forms and product cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c89e59e4832089cc3174fddf9afc